### PR TITLE
feat: Add SkillAttribution and DeleteSkillAttribution events to socket definition

### DIFF
--- a/src/defs/chat.ts
+++ b/src/defs/chat.ts
@@ -320,3 +320,91 @@ export interface IClearMessage {
         user_level: number;
     };
 }
+
+export interface ISkillAttribution {
+    /**
+     * The Id of the message.
+     */
+    id: string;
+    /**
+     * The skill being triggered
+     */
+    skill: {
+        /**
+         * The skill's Id.
+         */
+        skill_id: string;
+        /**
+         * The skill's name.
+         */
+        skill_name: string;
+        /**
+         * The skill's execution id.
+         */
+        execution_id: string;
+        /**
+         * The skill's icon url.
+         */
+        icon_url: string;
+        /**
+         * The amount of currency used to trigger skill.
+         */
+        cost: number;
+        /**
+         * The type of currency used to trigger skill.
+         */
+        currency: 'Sparks' | 'Embers';
+    };
+    /**
+     * The user's Id.
+     */
+    user_id: number;
+    /**
+     * The user's level.
+     */
+    user_level: number;
+    /**
+     * The user's name.
+     */
+    user_name: string;
+    /**
+     * The roles the user has.
+     */
+    user_roles: string[];
+    /**
+     * The user's avatar url
+     */
+    user_avatar: string;
+    /**
+     * The message payload.
+     */
+    message: IMessagePacketComponents;
+}
+
+export interface IDeleteSkillAttribution {
+    /**
+     * The skill's execution id.
+     */
+    execution_id: string;
+    /**
+     * The moderator that performed the action.
+     */
+    moderator: {
+        /**
+         * The moderator's Id.
+         */
+        user_id: number;
+        /**
+         * The moderator's name.
+         */
+        user_name: string;
+        /**
+         * The roles the moderator has.
+         */
+        user_roles: string[];
+        /**
+         * The level of the moderator
+         */
+        user_level: number;
+    };
+}

--- a/src/socket/Socket.ts
+++ b/src/socket/Socket.ts
@@ -11,6 +11,8 @@ import {
     IUserConnection,
     IUserTimeout,
     IUserUpdate,
+    IDeleteSkillAttribution,
+    ISkillAttribution,
 } from '../defs/chat';
 import {
     AuthenticationFailedError,
@@ -182,6 +184,8 @@ export class Socket extends EventEmitter {
     public on(event: 'UserLeave', cb: (join: IUserConnection) => any): this;
     public on(event: 'UserTimeout', cb: (timeout: IUserTimeout) => any): this;
     public on(event: 'UserUpdate', cb: (update: IUserUpdate) => any): this;
+    public on(event: 'SkillAttribution', cb: (update: ISkillAttribution) => any): this;
+    public on(event: 'DeleteSkillAttribution', cb: (update: IDeleteSkillAttribution) => any): this;
     // tslint:disable-next-line: no-unnecessary-override
     public on(event: string, cb: any): this {
         return super.on(event, cb);


### PR DESCRIPTION
The SkillAttribution event definitions are based on the docs here:

https://dev.mixer.com/reference/chat/events/skillattribution